### PR TITLE
Setup GitHub Pages deploy + SPA fallback + router + Vite base

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,42 +2,53 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main]
-  workflow_dispatch:
+    branches: ["main"]
 
 permissions:
   contents: read
   pages: write
   id-token: write
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # Derive the base path from the repo name so we don't hardcode it
+      VITE_BASE_PATH: /${{ github.event.repository.name }}/
+      VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+      VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+      VITE_DEFAULT_TZ: ${{ secrets.VITE_DEFAULT_TZ }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
-      - run: npm ci
-      - run: npm run build
-        env:
-          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
-          VITE_DEFAULT_TZ: ${{ secrets.VITE_DEFAULT_TZ }}
-      - uses: actions/upload-pages-artifact@v3
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # SPA fallback for GitHub Pages (so deep links render)
+      - name: Add SPA fallback
+        run: cp dist/index.html dist/404.html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
           path: dist
+
   deploy:
-    needs: build
-    runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
     steps:
-      - uses: actions/deploy-pages@v4
-        id: deploy
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -34,3 +34,18 @@ values
   (1, '2024-01-01', 'Easy'),
   (2, '2024-01-01', 'Hard');
 ```
+
+## Deployment (GitHub Pages)
+
+This project deploys via GitHub Actions. Required **Actions secrets**:
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+- `VITE_DEFAULT_TZ` (e.g. `Europe/Dublin`)
+
+The workflow sets `VITE_BASE_PATH` automatically to `/<repo-name>/`, so no manual edits are needed after renaming the repo.
+
+Your site will be live at: `https://<username>.github.io/<repo>/`.
+
+Troubleshooting:
+- Deep-link 404s: the workflow copies `index.html` to `404.html` and routing uses `HashRouter`; both must be present.
+- Missing Supabase envs: check Actions logs for the warning and add the secrets in **Settings → Secrets and variables → Actions**.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Routes, Route, Link, Navigate, useNavigate } from 'react-router-dom';
 import type { Session } from '@supabase/supabase-js';
-import { supabase } from './supabase';
+import { supabase } from './lib/supabase';
 import Home from './pages/Home';
 import Play from './pages/Play';
 import Leaderboard from './pages/Leaderboard';

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = import.meta.env.VITE_SUPABASE_URL as string;
+const anon = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+if (!url || !anon) {
+  console.warn('Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY');
+}
+
+export const supabase = createClient(url, anon);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { HashRouter } from 'react-router-dom';
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>
 );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { supabase } from '../supabase';
+import { supabase } from '../lib/supabase';
 
 interface Puzzle {
   id: number;

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { supabase } from '../supabase';
+import { supabase } from '../lib/supabase';
 
 interface Row {
   rank: number;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { supabase } from '../supabase';
+import { supabase } from '../lib/supabase';
 
 export default function Login() {
   const [email, setEmail] = useState('');

--- a/src/pages/Play.tsx
+++ b/src/pages/Play.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { supabase } from '../supabase';
+import { supabase } from '../lib/supabase';
 
 export default function Play() {
   const { puzzleId } = useParams();

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '../supabase';
+import { supabase } from '../lib/supabase';
 
 export default function Profile() {
   const [displayName, setDisplayName] = useState('');

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -1,6 +1,0 @@
-import { createClient } from '@supabase/supabase-js';
-
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+// Use env-based base path so this works for any repo name without edits.
+// The workflow sets VITE_BASE_PATH to "/<repo-name>/" automatically.
 export default defineConfig({
-  base: './',
+  base: process.env.VITE_BASE_PATH || '/',
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- configure GitHub Actions workflow to build and deploy via Pages with SPA fallback and env-driven base path
- switch routing to `HashRouter` and use env-based Vite `base` for flexible repo names
- add minimal Supabase client and document required deployment secrets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `VITE_SUPABASE_URL=http://example.com VITE_SUPABASE_ANON_KEY=anon VITE_DEFAULT_TZ=Europe/Dublin npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f35d5969083288da2be189238b82a